### PR TITLE
Add custom event jobCreated

### DIFF
--- a/src/actions/basiqConnectAction.js
+++ b/src/actions/basiqConnectAction.js
@@ -239,6 +239,14 @@ export const connectToBank = (selectedInstitution, institutionId, loginId, passw
     if (!response.ok) {
         dispatch(bankConnectFailed(response.errors[0]));
         return;
+    } else {
+        const connection = new CustomEvent("jobCreated", {
+            detail: {
+                id: response.payload.id,
+                link: response.payload.links.self
+            }
+        });
+        window.dispatchEvent(connection)
     }
 
     const abortController = apiService.addJobStatusChangedCallback(response.payload.id, getState, (status) => {


### PR DESCRIPTION
Have added a custom event to be triggered when a job is successfully created, passing the id and link to the job. This will ease integration for customers as subscribing to this removes the need to poll for new jobs created in the background, and just check for success on each created job.