### PR TITLE
Add custom event on BasiqConnect mounted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@basiq/basiq-connect-control",
-  "version": "1.0.59",
+  "version": "1.0.61",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@basiq/basiq-connect-control",
-    "version": "1.0.60",
+    "version": "1.0.61",
     "main": "dist/main.js",
     "files": [
         "dist/*"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import ElementQueries from "css-element-queries/src/ElementQueries";
 
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 
@@ -16,6 +16,11 @@ ElementQueries.listen();
 ElementQueries.init();
 
 const BasiqConnect = (inputs) => {
+
+  useEffect(() => {
+    window.dispatchEvent(new CustomEvent("basiqConnectMounted"));
+  }, [])
+
   if(inputs && inputs.containerId !== null){
     const { containerId, connectLinkId, token, userID, connect, upload, companyName, regionOfInstitutions, hideTestBanks, hideBetaBanks } = inputs;
     ReactDOM.render(


### PR DESCRIPTION
After receiving feedback from customers (specifically Afterpay Money) regarding a delay in loading of the UI component, I have added a custom event which will be triggered when the component has loaded. This was a requested workaround so the customer can listen for the event and only show this component when it has loaded. 

Happy to discuss if there is any feedback :) 