### PR TITLE
Remove json formatted markdown to fix docs bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following parameters can be passed through the config object. Most are optio
 
 - the connectLinkId, which is the link returned from `/users/{user.id}/auth_link`
 
-```json
+```
 {
     containerId: String, // ID of the DOM element to which Basiq Connect Control will be rendered; 
 


### PR DESCRIPTION
The updated json formatting introduced some odd behaviour on some machines so removing this to revert.
<img width="1074" alt="Screenshot 2021-09-27 at 17 25 35" src="https://user-images.githubusercontent.com/86027648/134972993-636d37a2-970d-4c34-8f29-10b4e3a4218f.png">
