### PR TITLE
Remove e superfund condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@basiq/basiq-connect-control",
-  "version": "1.0.64",
+  "version": "1.0.67",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@basiq/basiq-connect-control",
-    "version": "1.0.66",
+    "version": "1.0.67",
     "main": "dist/main.js",
     "files": [
         "dist/*"

--- a/src/components/pages/SelectInstitution/SelectInstitutionPage.js
+++ b/src/components/pages/SelectInstitution/SelectInstitutionPage.js
@@ -11,8 +11,6 @@ import InstitutionTumbnail from "../../ui/InstitutionThumbnail/InstitutionThumbn
 
 import "./SelectInstitutionPage.css";
 
-const ESUPERFUND_PARTNER_ID = "8f6d03ae-e2ca-4bc9-950d-53f20b30ba73";
-
 class SelectInstitutionPage extends React.Component {
   constructor() {
     super();
@@ -60,8 +58,7 @@ class SelectInstitutionPage extends React.Component {
             ? institutions
               .filter(
                 institution =>
-                  // Removing test institutions if partner is eSuperfund
-                  (this.getPartnerId(accessToken) === ESUPERFUND_PARTNER_ID || hideTestBanks ?
+                  (hideTestBanks ?
                     (institution.id !== "AU00000" && institution.id !== "AU00001") : true) &&
                   (institution.shortName.toUpperCase().includes(this.state.searchString) ||
                   institution.name.toUpperCase().includes(this.state.searchString))


### PR DESCRIPTION
From eSuperfund 

> It has been a while since we last spoke. Can you please assist with the current issue we are facing when updating your API from v1.0 to v2.0, or direct us to the right person for the issue below:
> 
> we are updating to the new BASIQ NPM component and notice that the test banks are not showing even with the configuration is set to false. we find a special logic in the github source code, if the partnerId is esuperfund it will not show test banks, can you please remove this logic?
> 
> code reference: line 63 at  https://github.com/basiqio/basiq-connect-control/blob/aefdc7efdf76537d7c9058686065dcc889a97915/src/components/pages/SelectInstitution/SelectInstitutionPage.js
> 
> Please let us know if we shall schedule a call to clarify if needed. Looking forward to hearing from you.

This was a condition introduced in 2019 and is no longer valid. :) 